### PR TITLE
fix ios & safari backface visibility not working issue

### DIFF
--- a/src/flipNumber.js
+++ b/src/flipNumber.js
@@ -145,6 +145,7 @@ export default class FlipNumber extends React.Component<Props, State> {
                     color,
                     background,
                     backfaceVisibility: 'hidden',
+                    WebkitBackfaceVisibility: 'hidden',
                     transform: `rotateX(${rotateDegreePerNumber * i}deg) translateZ(${translateZ}px)`,
                     ...numberStyle,
                   }}


### PR DESCRIPTION
follow this [ref](https://stackoverflow.com/questions/42744573/backface-visibility-not-working-in-safari/45145977)

it works. Test on IOS 11.3.1 safari